### PR TITLE
Add Den: self-hosted sandbox runtime for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ This document provides a comprehensive, curated list and analysis of modern code
   - [4.1. e2b: The AI Agent Sandbox Runtime](#41-e2b-the-ai-agent-sandbox-runtime)
   - [4.2. Daytona: Secure & Elastic Infrastructure for AI Code](#42-daytona-secure--elastic-infrastructure-for-ai-code)
   - [4.3. microsandbox: Self-Hosted MicroVMs for Untrusted Code](#43-microsandbox-self-hosted-microvms-for-untrusted-code)
-  - [4.4. WebContainers: Browser-Native Development Runtime](#44-webcontainers-browser-native-development-runtime)
-  - [4.5. Replit: Collaborative Browser-Based Development](#45-replit-collaborative-browser-based-development)
-  - [4.6. Cloudflare Workers: Edge Computing with V8 Isolates](#46-cloudflare-workers-edge-computing-with-v8-isolates)
-  - [4.7. Fly.io: Modern Application Hosting with MicroVMs](#47-flyio-modern-application-hosting-with-microvms)
-  - [4.8. Kata Containers: Secure Container Runtime](#48-kata-containers-secure-container-runtime)
-  - [4.9. Other Notable Platforms & Cloud Development Environments (CDEs)](#49-other-notable-platforms--cloud-development-environments-cdes)
+  - [4.4. Den: Self-Hosted Sandbox Runtime for AI Agents](#44-den-self-hosted-sandbox-runtime-for-ai-agents)
+  - [4.5. WebContainers: Browser-Native Development Runtime](#45-webcontainers-browser-native-development-runtime)
+  - [4.6. Replit: Collaborative Browser-Based Development](#46-replit-collaborative-browser-based-development)
+  - [4.7. Cloudflare Workers: Edge Computing with V8 Isolates](#47-cloudflare-workers-edge-computing-with-v8-isolates)
+  - [4.8. Fly.io: Modern Application Hosting with MicroVMs](#48-flyio-modern-application-hosting-with-microvms)
+  - [4.9. Kata Containers: Secure Container Runtime](#49-kata-containers-secure-container-runtime)
+  - [4.10. Other Notable Platforms & Cloud Development Environments (CDEs)](#410-other-notable-platforms--cloud-development-environments-cdes)
 - [6. Docker vs MicroVM for Sandboxing](#6-docker-vs-microvm-for-sandboxing)
 - [7. Choosing Your Sandbox: A Decision Framework](#7-choosing-your-sandbox-a-decision-framework)
   - [Axis 1: Security vs. Performance vs. Compatibility](#axis-1-security-vs-performance-vs-compatibility)
@@ -92,7 +93,7 @@ Developed and open-sourced by Amazon Web Services (AWS), [Firecracker](https://f
 * **Security Model:** For defense-in-depth, Firecracker employs a companion "jailer" process. The jailer sets up a secure environment using Linux cgroups and namespaces to isolate the Firecracker VMM process itself before dropping its privileges. This provides a second layer of containment in the unlikely event that the virtualization barrier is compromised.  
 * **Adoption:** This technology is the foundation for many major platforms:
   - [**e2b** ↓](#41-e2b-the-ai-agent-sandbox-runtime) - leverages Firecracker for secure, fast-starting sandboxes for AI agents
-  - [**Fly.io** ↓](#47-flyio-modern-application-hosting-with-microvms) - uses Firecracker microVMs for modern application hosting
+  - [**Fly.io** ↓](#48-flyio-modern-application-hosting-with-microvms) - uses Firecracker microVMs for modern application hosting
   - **AWS Lambda** - Amazon's serverless computing service runs on Firecracker
   - **AWS Fargate** - Amazon's container hosting service uses Firecracker for isolation
 
@@ -162,7 +163,7 @@ This is the most lightweight form of sandboxing, where isolation is enforced by 
 * **Memory Safety:** WASM code executes in a linear memory space that is completely isolated from the host process's memory. Every memory access is automatically bounds-checked by the runtime, preventing buffer overflows from affecting the host or other WASM modules. The call stack is also managed by the runtime and is inaccessible to the WASM code, which neutralizes traditional stack-smashing attacks.  
 * **Capability-Based Security:** A WASM module is inert by default. It has no intrinsic ability to access the file system, network, or any other external resource. To perform any I/O, the host environment must explicitly provide these capabilities by passing in functions (known as "imports") during instantiation. This "default-deny" posture ensures that a module can only do what it has been explicitly permitted to do.
 * **Adoption:** This technology is used across many platforms:
-  - [**WebContainers** ↓](#44-webcontainers-browser-native-development-runtime) - uses WASM for browser-based Node.js runtime
+  - [**WebContainers** ↓](#45-webcontainers-browser-native-development-runtime) - uses WASM for browser-based Node.js runtime
   - **Shopify Scripts** - uses WASM for safe execution of custom scripts
   - **Fastly Compute@Edge** - uses WASM for edge computing
   - **Wasmtime** - server-side WASM runtime
@@ -181,7 +182,7 @@ V8 Isolates are a core feature of Google's V8 JavaScript engine. An Isolate repr
 * **Language-Specific Limitations:** While V8 Isolates excel at JavaScript execution, they are not well-suited for Python workloads. The V8 engine is specifically designed and optimized for JavaScript's execution model, memory management, and runtime characteristics. Python applications require different runtime environments and cannot benefit from V8's isolation technology. For Python sandboxing, alternative approaches like nsjail, gVisor, or microVMs are more appropriate choices.
 * **The V8 Sandbox:** It is important to distinguish V8 Isolates from the newer [V8 Sandbox](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/main/src/sandbox/README.md). The V8 Sandbox is a further defense-in-depth measure that operates *within* an isolate. It reserves a large region of virtual address space and ensures that all V8 heap pointers are confined to that space. This is designed to mitigate the impact of potential vulnerabilities *within the V8 engine itself*, preventing an exploit from achieving arbitrary memory read/write capabilities outside the sandboxed region. This demonstrates a multi-layered approach to security, even within the runtime.
 * **Adoption:** This technology powers major edge computing platforms:
-  - [**Cloudflare Workers** ↓](#46-cloudflare-workers-edge-computing-with-v8-isolates) - uses V8 Isolates for edge computing
+  - [**Cloudflare Workers** ↓](#47-cloudflare-workers-edge-computing-with-v8-isolates) - uses V8 Isolates for edge computing
   - **Deno Deploy** - uses V8 Isolates for serverless JavaScript
   - **Shopify Scripts** - uses V8 Isolates for safe script execution
   - **Chrome Browser** - uses V8 Isolates for tab isolation
@@ -210,9 +211,10 @@ Containerization represents the most widely adopted approach to application isol
 * **Enhanced Security Options:** Technologies like gVisor provide additional security layers for containers, while Kata Containers offer VM-level isolation with container compatibility.
 * **Adoption:** This technology is ubiquitous across the industry:
   - [**Daytona** ↓](#42-daytona-secure--elastic-infrastructure-for-ai-code) - uses containers for development environments
-  - [**Replit** ↓](#45-replit-collaborative-browser-based-development) - uses containers for coding environments
-  - [**Gitpod** ↓](#49-other-notable-platforms--cloud-development-environments-cdes) - uses containers for development workspaces
-  - [**Coder** ↓](#49-other-notable-platforms--cloud-development-environments-cdes) - uses containers for development environments
+  - [**Den** ↓](#44-den-self-hosted-sandbox-runtime-for-ai-agents) - uses Docker containers for AI agent sandboxes
+  - [**Replit** ↓](#46-replit-collaborative-browser-based-development) - uses containers for coding environments
+  - [**Gitpod** ↓](#410-other-notable-platforms--cloud-development-environments-cdes) - uses containers for development workspaces
+  - [**Coder** ↓](#410-other-notable-platforms--cloud-development-environments-cdes) - uses containers for development environments
   - **Kubernetes** - the foundation of modern container orchestration
   - **Docker Hub** - the largest container registry with billions of downloads
 
@@ -225,14 +227,15 @@ The following table provides a high-level, comparative overview of the leading c
 | [**e2b** ↓](#41-e2b-the-ai-agent-sandbox-runtime) | Firecracker (MicroVM) | Nov 2023 | 8.9k+ | Apache-2.0 | Yes | Yes | Persistent | Full | Short & Long-Running |
 | [**Daytona** ↓](#42-daytona-secure--elastic-infrastructure-for-ai-code) | Containers (OCI/Docker) | 2023 | 21k+ | AGPL-3.0 | Yes | Yes | Persistent, Archivable | Full | Long-Running & Stateful |
 | [**microsandbox** ↓](#43-microsandbox-self-hosted-microvms-for-untrusted-code) | libkrun (MicroVM) | May 2025 | 3.3k+ | Apache-2.0 | Yes (Primary) | No | Persistent & Ephemeral | Full | Short & Long-Running |
-| [**WebContainers** ↓](#44-webcontainers-browser-native-development-runtime) | Browser-based Node.js/Wasm | 2021 | N/A | Proprietary | No | Yes | Ephemeral | Browser-limited | Short & Medium-Running |
-| [**Replit** ↓](#45-replit-collaborative-browser-based-development) | Containers/VMs | 2016 | N/A | Proprietary | No | Yes | Persistent | Full | Short & Long-Running |
-| [**Cloudflare Workers** ↓](#46-cloudflare-workers-edge-computing-with-v8-isolates) | V8 Isolates | 2017 | N/A | Proprietary | No | Yes | Ephemeral | Edge-limited | Short-Running |
-| [**Fly.io** ↓](#47-flyio-modern-application-hosting-with-microvms) | MicroVMs (Firecracker) | 2017 | N/A | Proprietary | No | Yes | Persistent | Full | Short & Long-Running |
-| [**Kata Containers** ↓](#48-kata-containers-secure-container-runtime) | MicroVM Containers | 2017 | 5.2k+ | Apache-2.0 | Yes | No | Persistent | Full | Long-Running & Stateful |
-| [**CodeSandbox** ↓](#49-other-notable-platforms--cloud-development-environments-cdes) | MicroVM & Browser | 2017 | 13.4k+ | Proprietary / OSS Parts | No | Yes | Persistent | Full | Short & Long-Running |
-| [**Gitpod** ↓](#49-other-notable-platforms--cloud-development-environments-cdes) | Containers | 2020 | 12.9k+ | AGPL-3.0 | Yes | Yes | Persistent | Full | Long-Running & Stateful |
-| [**Coder** ↓](#49-other-notable-platforms--cloud-development-environments-cdes) | Containers / VMs | 2019 | 8.1k+ | AGPL-3.0 | Yes | Yes | Persistent | Full | Long-Running & Stateful |
+| [**Den** ↓](#44-den-self-hosted-sandbox-runtime-for-ai-agents) | Containers (Docker) | 2025 | 1.5k+ | AGPL-3.0 | Yes (Primary) | No | Persistent & Ephemeral | Full | Short & Long-Running |
+| [**WebContainers** ↓](#45-webcontainers-browser-native-development-runtime) | Browser-based Node.js/Wasm | 2021 | N/A | Proprietary | No | Yes | Ephemeral | Browser-limited | Short & Medium-Running |
+| [**Replit** ↓](#46-replit-collaborative-browser-based-development) | Containers/VMs | 2016 | N/A | Proprietary | No | Yes | Persistent | Full | Short & Long-Running |
+| [**Cloudflare Workers** ↓](#47-cloudflare-workers-edge-computing-with-v8-isolates) | V8 Isolates | 2017 | N/A | Proprietary | No | Yes | Ephemeral | Edge-limited | Short-Running |
+| [**Fly.io** ↓](#48-flyio-modern-application-hosting-with-microvms) | MicroVMs (Firecracker) | 2017 | N/A | Proprietary | No | Yes | Persistent | Full | Short & Long-Running |
+| [**Kata Containers** ↓](#49-kata-containers-secure-container-runtime) | MicroVM Containers | 2017 | 5.2k+ | Apache-2.0 | Yes | No | Persistent | Full | Long-Running & Stateful |
+| [**CodeSandbox** ↓](#410-other-notable-platforms--cloud-development-environments-cdes) | MicroVM & Browser | 2017 | 13.4k+ | Proprietary / OSS Parts | No | Yes | Persistent | Full | Short & Long-Running |
+| [**Gitpod** ↓](#410-other-notable-platforms--cloud-development-environments-cdes) | Containers | 2020 | 12.9k+ | AGPL-3.0 | Yes | Yes | Persistent | Full | Long-Running & Stateful |
+| [**Coder** ↓](#410-other-notable-platforms--cloud-development-environments-cdes) | Containers / VMs | 2019 | 8.1k+ | AGPL-3.0 | Yes | Yes | Persistent | Full | Long-Running & Stateful |
 
 ## **4\. In-Depth Platform Profiles**
 
@@ -289,7 +292,25 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Network Access:** The microsandbox core server is responsible for managing networking for the sandboxes. While detailed network configuration guides are not present in the primary documentation snippets, use cases such as "Web Browsing Agent" and "Instant App Hosting" strongly imply that sandboxes can be configured with controlled network access to fulfill these roles.  
   * **Workload Suitability:** microsandbox is highly flexible, catering to both **short-lived, stateless** tasks and **long-running, stateful** workloads. The msx command is designed for quick, ephemeral executions, while the project-based msr command with its persistent state is ideal for ongoing development work or complex, multi-step processes where context must be maintained.
 
-### **4.4. WebContainers: Browser-Native Development Runtime**
+### **4.4. Den: Self-Hosted Sandbox Runtime for AI Agents**
+
+* **Overview:** Den is a self-hosted sandbox runtime purpose-built for AI agents. Positioning itself as an open-source alternative to e2b, Den provides isolated Docker containers with a REST API, WebSocket streaming, and a built-in MCP server for seamless integration into agentic workflows. It emphasizes operational simplicity — a single binary that manages the full lifecycle of sandboxes including creation, execution, snapshot/restore, and dynamic memory management — while keeping all data and compute on your own infrastructure.
+* **GitHub:** [us/den](https://github.com/us/den)
+* **Website:** [den.dev](https://den.dev)
+* **Launch Date:** **2025** - Released as an open-source, self-hosted sandbox runtime targeting the growing AI agent ecosystem.
+* **GitHub Stars:** The project has approximately 1,500 stars.
+* **License:** **AGPL-3.0** - Strong copyleft license requiring network-accessible modifications to be released under the same terms. This is the same licensing strategy used by Daytona and Gitpod.
+* **Hosting:**
+  * **SaaS:** No. Den is exclusively a self-hosted solution, giving organizations full control over their sandboxing infrastructure and data.
+  * **Self-Hosted:** Yes. This is the only deployment model. Den runs as a single binary on your own servers, managing Docker containers for sandbox isolation.
+* **Capabilities:**
+  * **Filesystem Access:** Den supports both **persistent and ephemeral** filesystem modes. Sandboxes can maintain state across sessions through snapshot/restore functionality, or run as fully disposable environments for one-off tasks.
+  * **Network Access:** **Full** - Sandboxes have complete network access. The REST API and WebSocket streaming interface allow programmatic control over sandbox lifecycle and real-time interaction with running processes.
+  * **Workload Suitability:** Den is designed for both **short-lived and long-running** workloads. The snapshot/restore capability enables efficient pause/resume cycles for stateful agent tasks, while ephemeral mode supports rapid, disposable code execution. Dynamic memory management optimizes resource usage across concurrent sandboxes.
+* **Multi-Language SDKs:** Den provides official SDKs for **Go**, **TypeScript**, and **Python**, along with a built-in MCP server that enables direct integration with MCP-compatible AI agents and tool-use frameworks.
+* **Underlying Technology:** Den uses **Docker container isolation** with a streamlined operational model. Rather than requiring a complex orchestration stack, it runs as a single Go binary that communicates with the Docker daemon, making deployment straightforward on any machine with Docker installed.
+
+### **4.5. WebContainers: Browser-Native Development Runtime**
 
 * **Overview:** [WebContainers](https://webcontainers.io) represents a fundamentally different approach to code sandboxing by bringing server-side development entirely into the browser. Developed by StackBlitz, this technology creates a browser-based Node.js runtime using WebAssembly that can run package managers, development servers, and full-stack frameworks without any remote infrastructure.
 * **GitHub:** N/A (proprietary)
@@ -306,7 +327,7 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Workload Suitability:** Ideal for **short to medium-running** development tasks, prototyping, tutorials, and educational environments. Performance claims of up to 10x faster package installation than local development make it suitable for rapid iteration workflows.  
 * **Unique Value Proposition:** WebContainers eliminates server infrastructure costs entirely while providing instant, disposable development environments. This makes it particularly valuable for interactive tutorials, low-code platforms, and AI development environments where traditional server-based sandboxes would be cost-prohibitive at scale.
 
-### **4.5. Replit: Collaborative Browser-Based Development**
+### **4.6. Replit: Collaborative Browser-Based Development**
 
 * **Overview:** [Replit](https://replit.com) is a browser-based development platform that emphasizes collaboration, education, and rapid prototyping. Founded in 2016, it has become one of the most popular platforms for learning to code and building quick prototypes. The platform provides instant development environments without any local setup, supporting dozens of programming languages and frameworks.
 * **GitHub:** [replit](https://github.com/replit)
@@ -323,7 +344,7 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Workload Suitability:** Ideal for **short to long-running** development tasks, particularly educational projects, collaborative coding, and rapid prototyping. The platform excels at quick iterations and sharing code with others.  
 * **Unique Features:** Real-time collaboration, integrated AI coding assistance, one-click deployment, and strong community features make it particularly popular for education and team development.
 
-### **4.6. Cloudflare Workers: Edge Computing with V8 Isolates**
+### **4.7. Cloudflare Workers: Edge Computing with V8 Isolates**
 
 * **Overview:** [Cloudflare Workers](https://workers.cloudflare.com) represents the edge computing paradigm, running code across Cloudflare's global network of 275+ data centers. Launched in 2017, it uses V8 Isolates to provide extremely fast cold starts and global distribution, making it ideal for serverless functions that need to run close to users worldwide.
 * **GitHub:** N/A (proprietary)
@@ -340,7 +361,7 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Workload Suitability:** Exclusively for **short-running** tasks (10ms-30s execution time). Perfect for API endpoints, edge logic, and request transformation.  
 * **Performance:** Exceptional performance with 0ms cold starts and sub-100ms global latency. Claims to be up to 10x less expensive than traditional serverless platforms.
 
-### **4.7. Fly.io: Modern Application Hosting with MicroVMs**
+### **4.8. Fly.io: Modern Application Hosting with MicroVMs**
 
 * **Overview:** [Fly.io](https://fly.io) is a developer-focused cloud platform that runs applications using hardware-virtualized containers (microVMs) across 35 global regions. Founded in 2017, it bridges the gap between traditional VPS hosting and modern serverless platforms, offering the flexibility of VMs with the convenience of containerized deployment.
 * **GitHub:** N/A (proprietary)
@@ -357,7 +378,7 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Workload Suitability:** Supports both **short and long-running** workloads. Can scale from single request handling to always-on applications with thousands of instances.  
 * **Unique Value Proposition:** Combines the isolation benefits of microVMs with a developer-friendly deployment experience. Particularly strong for applications that need global distribution but require more than what edge computing platforms can provide.
 
-### **4.8. Kata Containers: Secure Container Runtime**
+### **4.9. Kata Containers: Secure Container Runtime**
 
 * **Overview:** [Kata Containers](https://katacontainers.io) is an open-source container runtime that delivers the speed of containers with the security of virtual machines. Launched in 2017 by the Open Infrastructure Foundation, it represents a unique approach to container security by running each container in its own lightweight virtual machine. This hybrid approach addresses the fundamental security concerns of traditional container runtimes while maintaining container ecosystem compatibility.
 * **GitHub:** [kata-containers/kata-containers](https://github.com/kata-containers/kata-containers)
@@ -374,7 +395,7 @@ The choice of the AGPL-3.0 license for Daytona's core product is a significant s
   * **Workload Suitability:** Ideal for **long-running, stateful** workloads that require strong security isolation. Perfect for multi-tenant environments, untrusted code execution, and compliance-heavy workloads where container escape vulnerabilities are unacceptable.  
 * **Unique Value Proposition:** Kata Containers solves the "container vs. VM" dilemma by providing both. Organizations get the operational benefits of containers (fast startup, density, orchestration) with the security guarantees of VMs (hardware isolation, dedicated kernel). This makes it particularly valuable for production environments running untrusted workloads or requiring regulatory compliance.
 
-### **4.9. Other Notable Platforms & Cloud Development Environments (CDEs)**
+### **4.10. Other Notable Platforms & Cloud Development Environments (CDEs)**
 
 While the platforms above are specialized sandboxing runtimes, the broader category of Cloud Development Environments (CDEs) also relies heavily on sandboxing technology to function. They provide a useful point of comparison.
 
@@ -500,7 +521,7 @@ Your organization's operational model and compliance requirements will determine
 * **For a Managed Service (SaaS):** If you want to accelerate development and offload the operational burden of managing sandboxing infrastructure, a SaaS platform is the best choice. These platforms offer usage-based pricing and handle all the scaling, maintenance, and security of the underlying infrastructure.  
   * **Recommended:** **e2b** and **Daytona** provide mature, feature-rich SaaS offerings.  
 * **For Full Control (Self-Hosted):** If you have strict data sovereignty, regulatory compliance (e.g., GDPR), or security policies that mandate running all infrastructure within your own network perimeter, a self-hosted solution is necessary.  
-  * **Recommended:** **microsandbox** is self-hosted by design and is the most straightforward choice for this model.  
+  * **Recommended:** **microsandbox** and **Den** are self-hosted by design and are the most straightforward choices for this model.
     **Daytona**, **e2b**, **Gitpod**, and **Coder** also offer robust self-hosting options, typically as part of their enterprise offerings.
 
 ### **Axis 4: AI/Agent-Specific vs. General-Purpose**
@@ -508,7 +529,7 @@ Your organization's operational model and compliance requirements will determine
 Finally, consider whether you need a tool tailored for a specific domain or a more general-purpose platform.
 
 * **For AI-Centric Workflows:** If you are building AI agents, code interpreters, or other LLM-powered applications, choosing a platform that is explicitly optimized for this domain can provide significant advantages. Their SDKs and features are often designed to solve common problems in agentic development.  
-  * **Recommended:** **e2b** and **Daytona** are heavily focused on the AI and agent use case.  
+  * **Recommended:** **e2b**, **Daytona**, and **Den** are heavily focused on the AI and agent use case.  
 * **For General-Purpose Execution/Development:** If your needs are broader, such as providing general-purpose development environments or a secure runtime for a variety of applications, a more general platform may be a better fit.  
   * **Recommended:** **microsandbox** is a powerful, general-purpose secure execution engine.  
     **Coder** and **Gitpod** are leading general-purpose Cloud Development Environments.


### PR DESCRIPTION
## Summary

Adds [Den](https://github.com/us/den) to the curated list of sandbox platforms.

Den is a self-hosted sandbox runtime built for AI agents — an open-source alternative to e2b. It uses Docker containers for isolation and ships as a single Go binary with a REST API, WebSocket streaming, built-in MCP server, snapshot/restore, dynamic memory management, and official Go/TypeScript/Python SDKs. Licensed under AGPL-3.0.

## Changes

- Added Den platform profile (section 4.4)
- Added Den to the feature matrix (section 3)
- Added Den to Docker/OCI adoption list (section 2.4)
- Referenced Den in the decision framework (sections 7.3 and 7.4)
- Renumbered subsequent sections accordingly